### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ docker run -d --name holesail \
   -e PORT=25565 \
   -e HOST=minecraft \
   -e CONNECTOR=very-super-secret \
+  -e PUBLIC=false \
   --network holesail \
   ghcr.io/anaxios/holesail-docker:latest
 ```


### PR DESCRIPTION
PUBLIC is true by default, this means that the container will crash with this code snippet as you cannot provide a connector in public mode.